### PR TITLE
Refactor cookie banner

### DIFF
--- a/src/CookieBanner/CookieBannerText.jsx
+++ b/src/CookieBanner/CookieBannerText.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { Hyperlink } from '@edx/paragon';
+
+const CookieBannerText = ({ nonPrivacyPolicyText, privacyPolicyText, privacyPolicyDestination }) => {
+  return (
+    <span>
+      { nonPrivacyPolicyText }
+      <Hyperlink content={privacyPolicyText} destination={privacyPolicyDestination} />
+      { '.' }
+    </span>
+  );
+};
+
+export default CookieBannerText;

--- a/src/CookieBanner/index.jsx
+++ b/src/CookieBanner/index.jsx
@@ -8,7 +8,12 @@ import {
   LANGUAGE_CODES_TO_CONTAINER_ROLE_LABEL,
   getPolicyHTML,
 } from '../constants';
-import { getLanguageCode, hasViewedCookieBanner, createHasViewedCookieBanner } from '../utilities';
+import {
+  getLanguageCode,
+  hasViewedCookieBanner,
+  createHasViewedCookieBanner,
+} from '../utilities';
+import CookieBannerText from './CookieBannerText';
 
 class CookieBanner extends Component {
   constructor(props) {
@@ -52,9 +57,9 @@ class CookieBanner extends Component {
         >
           <StatusAlert
             className={['edx-cookie-banner']}
-            open={this.state.open}
+            open={open}
             closeButtonAriaLabel={LANGUAGE_CODES_TO_CLOSE_BUTTON_LABEL[langCode]}
-            dialog={(<span dangerouslySetInnerHTML={{ __html: getPolicyHTML(langCode) }} />)}
+            dialog={<CookieBannerText nonPrivacyPolicyText="foo fucking" privacyPolicyText=" bar " privacyPolicyDestination="https://www.edx.org" />}
             onClose={this.onClose}
           />
         </div>


### PR DESCRIPTION
Instead of `dangerouslySettingInnerHTML` this creates a `CookieBannerText` wrapper component that uses [the Paragon `Hyperlink` component](https://github.com/edx/paragon/blob/master/src/Hyperlink/index.jsx) to build the input for the `dialog` prop for the `StatusAlert`.

This also adds default banner and close button labels if the language code is currently unmapped.