### PR TITLE
set path to "/" so that the cookie is used everywhere

### DIFF
--- a/src/utilities.js
+++ b/src/utilities.js
@@ -26,10 +26,13 @@ const getLanguageCode = () => {
 };
 
 const createHasViewedCookieBanner = () => {
+  const path = '/';
+  const maxAge = Number.MAX_SAFE_INTEGER;
+
   if (isStage()) {
-    return new Cookie().set('edx-cookie-policy-viewed', true, { domain: '.stage.edx.org' });
+    return new Cookie().set('edx-cookie-policy-viewed', true, { domain: '.stage.edx.org', path, maxAge });
   } else if (isProduction()) {
-    return new Cookie().set('edx-cookie-policy-viewed', true, { domain: '.edx.org' });
+    return new Cookie().set('edx-cookie-policy-viewed', true, { domain: '.edx.org', path, maxAge });
   }
 
   return false;


### PR DESCRIPTION
Here are [the `set` options for `universal-cookie`](https://github.com/reactivestack/cookies/tree/master/packages/universal-cookie#setname-value-options).

![image](https://user-images.githubusercontent.com/8136030/38633886-f73d1690-3d8e-11e8-9801-4bb75bf8b687.png)

So when I test on an `edx-platform` sandbox and I go to any page, like theming, for example, for the first time, I see the cookie banner, unsurprisingly

![image](https://user-images.githubusercontent.com/8136030/38633920-0b291ec4-3d8f-11e8-8309-ceabc798c372.png)

But the `edx-cookie-policy-viewed` cookie has a `path` value of `\theming`. So when I go to `\dashboard` I see the cookie banner again!

![image](https://user-images.githubusercontent.com/8136030/38634094-8bdb95e2-3d8f-11e8-9615-4f83d7700dd6.png)

I *think* this might be due to the `path` because if I go back to `\theming` I don't see the banner but I **do** see 2 cookies

![image](https://user-images.githubusercontent.com/8136030/38634270-0c7ff24c-3d90-11e8-8095-016d2f05af23.png)

In addition, do we want to set values for `expires` / `maxAge`?