### PR TITLE
use expires

### DIFF
--- a/src/utilities.js
+++ b/src/utilities.js
@@ -27,12 +27,13 @@ const getLanguageCode = () => {
 
 const createHasViewedCookieBanner = () => {
   const path = '/';
-  const maxAge = Number.MAX_SAFE_INTEGER;
+  // maximum date http://www.ecma-international.org/ecma-262/5.1/#sec-15.9.1.1
+  const expires = new Date(8640000000000000);
 
   if (isStage()) {
-    return new Cookie().set('edx-cookie-policy-viewed', true, { domain: '.stage.edx.org', path, maxAge });
+    return new Cookie().set('edx-cookie-policy-viewed', true, { domain: '.stage.edx.org', path, expires });
   } else if (isProduction()) {
-    return new Cookie().set('edx-cookie-policy-viewed', true, { domain: '.edx.org', path, maxAge });
+    return new Cookie().set('edx-cookie-policy-viewed', true, { domain: '.edx.org', path, expires });
   }
 
   return false;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8136030/38763075-50824e08-3f62-11e8-954b-17741f9536e1.png)

It seems the `maxAge` isn't setting the cookie expiration properly - instead it's setting a session cookie. I'm guessing this is because a `maxAge` of `Number.MAX_SAFE_INTEGER` isn't evaluated properly.