### PR TITLE
Add stage prefixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/cookie-policy-banner",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "The edX cookie policy banner component implemented in React.",
   "main": "build/index.js",
   "style": "build/_cookie-policy-banner.scss",

--- a/src/constants.js
+++ b/src/constants.js
@@ -2,13 +2,18 @@ const ENGLISH_IETF_TAG = 'en';
 const SPANISH_IETF_TAG = 'es-419';
 const DEFAULT_IETF_TAG = ENGLISH_IETF_TAG;
 const LOCALHOST = 'localhost';
-const STAGE_ENVIRONMENTS = [
-  'acceptance.edx.org',
-  'dev.edx.org',
-  'extra.edx.org',
-  'qa.edx.org',
-  'stage.edx.org',
-];
+const ACCEPTANCE = 'ACCEPTANCE';
+const DEV = 'DEV';
+const EXTRA = 'EXTRA';
+const QA = 'QA';
+const STAGE = 'STAGE';
+const STAGE_ENVIRONMENTS = Object.freeze({
+  [ACCEPTANCE]: { baseURL: 'acceptance.edx.org', prefix: 'acceptance' },
+  [DEV]: { baseURL: 'dev.edx.org', prefix: 'dev' },
+  [EXTRA]: { baseURL: 'extra.edx.org', prefix: 'extra' },
+  [QA]: { baseURL: 'qa.edx.org', prefix: 'qa' },
+  [STAGE]: { baseURL: 'stage.edx.org', prefix: 'stage' },
+});
 
 const LANGUAGE_CODES = Object.freeze([ENGLISH_IETF_TAG, SPANISH_IETF_TAG]);
 
@@ -42,7 +47,7 @@ export {
   LANGUAGE_CODES_TO_CLOSE_BUTTON_LABEL,
   LANGUAGE_CODES_TO_CONTAINER_ROLE_LABEL,
   getPolicyHTML,
-  STAGE_ENVIRONMENTS,
   LOCALHOST,
   COOKIE_POLICY_VIEWED_NAME,
+  STAGE_ENVIRONMENTS,
 };


### PR DESCRIPTION
I forgot something as part of #14 - we probably want the cookie to be namespaced by the environment (`localhost-edx-cookie-policy-viewed` vs. `prod-edx-cookie-policy-viewed`) so that when we check to see if the cookie exists on, say, `stage`, the behavior is not modified by the fact that we were testing on `localhost`.

![image](https://user-images.githubusercontent.com/8136030/39203528-09f14f02-47c3-11e8-9754-7dfa10628239.png)
