### PR TITLE
downgrade react peer dependency to 16.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/cookie-policy-banner",
-  "version": "1.1.7",
+  "version": "1.1.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@edx/cookie-policy-banner",
-  "version": "1.1.8",
+  "version": "1.1.9",
   "description": "The edX cookie policy banner component implemented in React.",
   "main": "build/index.js",
   "style": "build/_cookie-policy-banner.scss",
@@ -47,8 +47,8 @@
     "universal-cookie": "^2.1.2"
   },
   "peerDependencies": {
-    "react": "^16.3.0",
-    "react-dom": "^16.3.0"
+    "react": "^16.1.0",
+    "react-dom": "^16.1.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^6.1.3",


### PR DESCRIPTION
[edx/platform uses `react` `v16.1.0`](https://github.com/edx/edx-platform/blob/master/package.json?utf8=%E2%9C%93#L43).

This causes peer dependency warnings when installing the `cookie-policy-banner`

```
npm WARN @edx/cookie-policy-banner@1.1.8 requires a peer of react@^16.3.0 but none is installed. You must install peer dependencies yourself.
```